### PR TITLE
Fix output getting deleted during 2nd pass of incremental compilation

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -292,8 +292,17 @@ class KotlinBuilder
             argMap.optional(KotlinBuilderFlags.COMPILER_PLUGIN_CLASS_PATH) ?: emptyList(),
           )
 
+          // Kotlin compiler always requires absolute path for source input in incremental mode
+          val useAbsolutePath = argMap.optionalSingle(KotlinBuilderFlags.INCREMENTAL_COMPILATION) == "true"
           argMap
             .optional(KotlinBuilderFlags.SOURCES)
+            ?.map {
+              if (useAbsolutePath) {
+                FileSystems.getDefault().getPath(it).toAbsolutePath().toString()
+              } else {
+                it
+              }
+            }
             ?.iterator()
             ?.partitionJvmSources(
               { addKotlinSources(it) },


### PR DESCRIPTION
It's mandatory to use absolute path for kotlin source files in order for incremental compilation to work as expected. Otherwise, a second compilation will delete the output unexpectedly.