### PR TITLE
Invalidate snapshot when underlying (abi) jar changes

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/ClasspathSnapshotGenerator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/ClasspathSnapshotGenerator.kt
@@ -1,12 +1,12 @@
 package io.bazel.kotlin.builder.tasks.jvm
 
+import java.io.FileInputStream
+import java.nio.file.Files
 import java.nio.file.Path
+import java.security.MessageDigest
 import kotlin.system.measureTimeMillis
 import org.jetbrains.kotlin.buildtools.api.CompilationService
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
-import org.jetbrains.kotlin.buildtools.api.KotlinLogger
-import java.io.File
-import java.util.logging.Logger
 import kotlin.io.path.exists
 
 @OptIn(ExperimentalBuildToolsApi::class)
@@ -16,16 +16,47 @@ class ClasspathSnapshotGenerator(
     private val granularity: SnapshotGranularity
 ) {
 
+    private val hashPath: Path by lazy {
+      outputSnapshot.resolveSibling(outputSnapshot.fileName.toString() + ".hash")
+    }
+
     fun run() {
-        // if (outputSnapshot.exists()) { return }
-        val timeSpent = measureTimeMillis {
-            val compilationService = CompilationService.loadImplementation(this.javaClass.classLoader!!)
-            val snapshot =
-                compilationService.calculateClasspathSnapshot(
-                    inputJar.toFile(), granularity.toClassSnapshotGranularity)
-            snapshot.saveSnapshot(outputSnapshot.toFile())
+        if (outputSnapshot.exists() and hashPath.exists() and !isSnapshotOutdated()) {
+          return
         }
+
+        val timeSpent = measureTimeMillis {
+          val compilationService =
+            CompilationService.loadImplementation(this.javaClass.classLoader!!)
+          val snapshot =
+            compilationService.calculateClasspathSnapshot(
+              inputJar.toFile(), granularity.toClassSnapshotGranularity
+            )
+          // TODO : make things atomic / avoid race conditions
+          val hash = hashFile(inputJar)
+          snapshot.saveSnapshot(outputSnapshot.toFile())
+          hashPath.toFile().writeText(hash)
+        }
+
         // TODO: Log impl
         // LOG.info("$timeSpent ms for input jar: $inputJar")
+    }
+
+    private fun isSnapshotOutdated(): Boolean {
+      val storedHash = Files.readAllLines(hashPath).firstOrNull()?.trim()
+      val currentHash = hashFile(outputSnapshot)
+      return storedHash == null || storedHash != currentHash
+    }
+
+    private fun hashFile(path: Path): String {
+      val digest = MessageDigest.getInstance("SHA-256")
+      FileInputStream(path.toFile()).use { fis ->
+        val buffer = ByteArray(8192)
+        var bytesRead: Int
+        while (fis.read(buffer).also { bytesRead = it } != -1) {
+          digest.update(buffer, 0, bytesRead)
+        }
+      }
+      return digest.digest().joinToString("") { "%02x".format(it) }
     }
 }


### PR DESCRIPTION
This is needed in order to cause invalidated downstream targets to rebuild against the updated code.

Test : use 2 kotlin libraries (ktlib1-> ktlib2), have ktlib1 invoke method from ktlib2, build. suppress method from ktlib2, rebuild -> compilation failure (as expected). Wihtout the change ktlib1 succeeds to compile, which is not correct.