### PR TITLE
Properly hook up flags to control build tool API / incremental compilation enabling

### DIFF
--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -91,8 +91,8 @@ def _kotlin_toolchain_impl(ctx):
         experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
         experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
         experimental_reduce_classpath_mode = ctx.attr.experimental_reduce_classpath_mode,
-        experimental_build_tools_api = ctx.attr.experimental_build_tools_api,
-        experimental_incremental_compilation = ctx.attr.experimental_incremental_compilation,
+        experimental_build_tools_api = ctx.attr.experimental_build_tools_api[BuildSettingInfo].value,
+        experimental_incremental_compilation = ctx.attr.experimental_incremental_compilation[BuildSettingInfo].value,
         javac_options = ctx.attr.javac_options[JavacOptions] if ctx.attr.javac_options else None,
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
         empty_jar = ctx.file._empty_jar,
@@ -249,13 +249,15 @@ _kt_toolchain = rule(
                 "KOTLINBUILDER_REDUCED",
             ],
         ),
-        "experimental_build_tools_api": attr.bool(
+        "experimental_build_tools_api": attr.label(
             doc = "Enables experimental support for Build Tools API integration",
             default = False,
+            default = Label("//kotlin/settings:experimental_build_tools_api"),
         ),
-        "experimental_incremental_compilation": attr.bool(
+        "experimental_incremental_compilation": attr.label(
             doc = "TODO",
             default = False,
+            default = Label("//kotlin/settings:experimental_incremental_compilation"),
         ),
         "javac_options": attr.label(
             doc = "Compiler options for javac",

--- a/kotlin/settings/BUILD.release.bazel
+++ b/kotlin/settings/BUILD.release.bazel
@@ -40,3 +40,10 @@ bool_flag(
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
+
+# --@rules_kotlin//kotlin/settings:experimental_incremental_compilation=True
+bool_flag(
+    name = "experimental_incremental_compilation",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Incremental compilation can be now turned on/off from command line

`bazel build //apps/presidio/carbon/carbon-app/carbon-apk:src_debug --@rules_kotlin//kotlin/settings:experimental_incremental_compilation=True --@rules_kotlin//kotlin/settings:experimental_build_tools_api=True`

or via .bazelrc

```
build:incremental --@rules_kotlin//kotlin/settings:experimental_incremental_compilation=True
build:incremental --@rules_kotlin//kotlin/settings:experimental_build_tools_api=True
```