### PR TITLE
Restore temporary working directory logic

### DIFF
--- a/src/main/kotlin/io/bazel/worker/WorkingDirectoryContext.kt
+++ b/src/main/kotlin/io/bazel/worker/WorkingDirectoryContext.kt
@@ -31,14 +31,12 @@ class WorkingDirectoryContext(
     val logger: Logger = Logger.getLogger(WorkingDirectoryContext::class.java.canonicalName)
 
     inline fun <T> use(forWork: WorkingDirectoryContext.() -> T) =
-      // TODO: Find a good place to persist this, keep ephemeral directory for non-incremental
-      WorkingDirectoryContext(java.nio.file.Paths.get("/tmp/kotlin_working_directory")).use { wd ->
+      WorkingDirectoryContext(Files.createTempDirectory("pwd")).use { wd ->
         wd.forWork()
       }
   }
 
   override fun close() {
-    return
     kotlin
       .runCatching {
         Files.walk(dir).sorted(Comparator.reverseOrder()).forEach(Files::delete)


### PR DESCRIPTION
- kotlin compiler (temporary) output is not under workspace `_kotlin_incremental` folder, similiarly to other kotlin incremental files (snapshot etc.)
- this is a pre-requisite to persist jdeps output file as well, which will be needed for merging in subsequent PR implementing handling of incremental jdeps